### PR TITLE
Add github-actions workflow for building Docker image

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -1,0 +1,21 @@
+name: Build Docker image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "r*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@2.7
+      with:
+        name: nicholastmosher/swen343-inventory
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,17 +1,19 @@
-name: Rust
+name: Build and Test
 
 on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
-    - name: Install
+
+    - name: Install backend dependencies
       run: sudo apt-get install libpq-dev
-    - name: Build
+    - name: Build backend
       run: cargo build --manifest-path=backend/Cargo.toml --verbose
-    - name: Run tests
+    - name: Run backend tests
       run: cargo test --manifest-path=backend/Cargo.toml --verbose
+
+    - name: Build frontend
+      run: "(cd frontend; yarn && yarn build)"


### PR DESCRIPTION
This renames the `rust.yml` workflow to `ci-test.yml` and it now runs both backend and frontend tests.
It also adds a `ci-deploy.yml` file which only triggers when a commit is merged to master or when a tag matching `r*` is pushed.