### PR TITLE
Change some straggling anchor tags to react-router-dom Link

### DIFF
--- a/frontend/src/view/Warehouses.tsx
+++ b/frontend/src/view/Warehouses.tsx
@@ -5,6 +5,7 @@ import { Warehouse } from "../types/Interfaces";
 import { ThunkDispatch } from "redux-thunk";
 import CreateEntityCard from "./components/CreateEntityCard";
 import {fetchWarehouses} from "../actions/ItemActions";
+import {Link} from "react-router-dom";
 
 interface StateProps {
   warehouses: Warehouse[],
@@ -27,10 +28,10 @@ class Items extends Component<Props, {}> {
 
     const warehouseComponents = warehouses.map((warehouse: Warehouse) => (
       <div className="item-card col-sm-6">
-        <a href={`/warehouse/${warehouse.name}`}>
+        <Link to={`/warehouse/${warehouse.name}`}>
           <h2>Warehouse: {warehouse.name}</h2>
           <div className="details">{warehouse.address}</div>
-        </a>
+        </Link>
       </div>
     ));
 

--- a/frontend/src/view/components/ContentHeader.tsx
+++ b/frontend/src/view/components/ContentHeader.tsx
@@ -12,9 +12,9 @@ const ContentHeader: React.FC<Props> = (props: Props) => {
   return (
     <div className="nav">
       <div className="nav-header">
-        <a className="inventory-link" href="/">
+        <Link className="inventory-link" to="/">
           <h1 className="inventory-header">Inventory Management</h1>
-        </a>
+        </Link>
         {headerLink}
       </div>
     </div>


### PR DESCRIPTION
Some of the links on the webpage were using the straight `<a></a>` tags, which causes incorrect behavior with how we've mounted the application under `/app/#/`. In the future, we should instead of using any `<a href="/blah">Some link</a>` links, we should use `<Link to="/blah">Some link</Link>`