### PR TITLE
Add log crate to provide info, warn, error, and debug macros

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,6 +23,7 @@ actix-cors = "0.1.0"
 env_logger = "0.7.0"
 actix-files = "0.1.6"
 reqwest = "0.9.22"
+log = "0.4.8"
 futures01 = { package = "futures", version = "0.1.29", optional = true }
 futures-preview = { version = "0.3.0-alpha.19", features = ["compat"] }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate diesel;
+#[macro_use]
+extern crate log;
 
 pub mod app;
 pub mod db;


### PR DESCRIPTION
This PR will allow us to put logging print statements throughout the rest of the codebase so we can keep track of important events, such as receiving a sales order, etc.

You use these macros the same way you use `println!`

```rust
info!("Something noteworthy happened");
warn!("Something might have mildly gone wrong! {:?}", some_details);
error!("A hard error happened!");
debug!("Let's just try to figure out what's going on");
```